### PR TITLE
Add '#field_parents' property to avoid warnings in other modules usin…

### DIFF
--- a/src/FormElement/MessageTemplateMultipleTextField.php
+++ b/src/FormElement/MessageTemplateMultipleTextField.php
@@ -61,6 +61,7 @@ class MessageTemplateMultipleTextField {
       '#description' => t('Please enter the message text.'),
       '#prefix' => '<div id="message-text">',
       '#suffix' => '</div>',
+      '#field_parents' => [],
     ];
 
     if (\Drupal::moduleHandler()->moduleExists('token')) {


### PR DESCRIPTION
…g this property